### PR TITLE
Use payload countryId from entries to ensure all countryId fields are payed respect to

### DIFF
--- a/src/Core/Service/LocationServiceV2.php
+++ b/src/Core/Service/LocationServiceV2.php
@@ -178,7 +178,7 @@ SQL;
         }
 
         try {
-            $countryIso = $this->getCountryIso($countryIds);
+            $countryIso = $this->getCountryIso([...$payload['countryIds'], $payload['countryId']);
 
             $params = [
                 "format" => "json",


### PR DESCRIPTION
Case:
When you select a country in the merchant finder, it will be passed as part of the payload as countryId. This is not used to lookup the countryIso and lookup fails. There is a way to use different countryIds, but they are not passed to this service. This parameter is also used in a way, that lets me think it is a fallback value, when no info is given. As this is a fallback value, it should not be used directly. Instead the values from the payload should be used. With that we have countryId and countryIds which both needs to be checked.

I hope this helps you to understand my case :)